### PR TITLE
Incorporation of a surface temperature-dependant albedo decay scheme (Bougamont et al., 2005)

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -11,7 +11,7 @@ z = 2.0                                         # Measurement height [m]
 
 ' PARAMETERIZATIONS '
 stability_correction = 'Ri'                     # possibilities: 'Ri','MO'
-albedo_method = 'Oerlemans98'                   # possibilities: 'Oerlemans98'
+albedo_method = 'Oerlemans98'                   # possibilities: 'Oerlemans98','Bougamont05'
 densification_method = 'Boone'                  # possibilities: 'Boone','empirical','constant' TODO: solve error Vionnet
 penetrating_method = 'Bintanja95'               # possibilities: 'Bintanja95'
 roughness_method = 'Moelg12'                    # possibilities: 'Moelg12'
@@ -71,6 +71,11 @@ albedo_mod_snow_depth = 3                       # effect of snow depth on albedo
 ### For tropical glaciers or High Mountain Asia summer-accumulation glaciers (low latitude), the Moelg et al. 2012, TC should be tested for a possible better albedo fit 
 #albedo_mod_snow_aging = 6                      # effect of ageing on snow albedo [days] (Moelg et al. 2012, TC)
 #albedo_mod_snow_depth = 8                      # effect of snow depth on albedo [cm] (Moelg et al. 2012, TC)
+
+t_star_wet = 10                                 # albedo decay timescale (melting surface) [days]
+t_star_dry = 30                                 # albedo decay timescale (dry snow surface) [days]
+t_star_K = 14                                   # increase in t_star_dry at negative temperatures [day K-1]
+t_star_cutoff = 263.17                          # temperature threshold for t_star_dry increase [K]
 
 roughness_fresh_snow = 0.24                     # surface roughness length for fresh snow [mm] (Moelg et al. 2012, TC)
 roughness_ice = 1.7                             # surface roughness length for ice [mm] (Moelg et al. 2012, TC)

--- a/cosipy/cpkernel/cosipy_core.py
+++ b/cosipy/cpkernel/cosipy_core.py
@@ -4,7 +4,7 @@ import pandas as pd
 from constants import mult_factor_RRR, densification_method, ice_density, water_density, \
                       minimum_snowfall, zero_temperature, lat_heat_sublimation, \
                       lat_heat_melting, lat_heat_vaporize, center_snow_transfer_function, \
-                      spread_snow_transfer_function, constant_density
+                      spread_snow_transfer_function, constant_density, albedo_fresh_snow
 from config import force_use_TP, force_use_N, stake_evaluation, full_field, WRF_X_CSPY 
 
 from cosipy.modules.albedo import updateAlbedo
@@ -161,6 +161,10 @@ def cosipy_core(DATA, indY, indX, GRID_RESTART=None, stake_names=None, stake_dat
 
     # Initial cumulative mass balance variable
     MB_cum = 0
+    
+    # Initial snow albedo and surface temperature for Bougamont et al. 2005 albedo
+    surface_temperature = 270.0
+    albedo_snow = albedo_fresh_snow
 
     if stake_evaluation:
         # Create pandas dataframe for stake evaluation
@@ -222,7 +226,7 @@ def cosipy_core(DATA, indY, indX, GRID_RESTART=None, stake_names=None, stake_dat
         #--------------------------------------------
         # Calculate albedo and roughness length changes if first layer is snow
         #--------------------------------------------
-        alpha = updateAlbedo(GRID)
+        alpha, albedo_snow = updateAlbedo(GRID,surface_temperature,albedo_snow)
 
         #--------------------------------------------
         # Update roughness length

--- a/cosipy/modules/albedo.py
+++ b/cosipy/modules/albedo.py
@@ -1,17 +1,18 @@
 import numpy as np
 from constants import albedo_method, albedo_fresh_snow, albedo_firn, albedo_ice, \
-                      albedo_mod_snow_aging, albedo_mod_snow_depth, snow_ice_threshold
+                      albedo_mod_snow_aging, albedo_mod_snow_depth, snow_ice_threshold, zero_temperature, dt, t_star_dry, t_star_wet, t_star_K, t_star_cutoff
 
-def updateAlbedo(GRID):
+def updateAlbedo(GRID,surface_temperature,albedo_snow):
     """ This methods updates the albedo """
-    albedo_allowed = ['Oerlemans98']
+    albedo_allowed = ['Oerlemans98','Bougamont05']
     if albedo_method == 'Oerlemans98':
         alphaMod = method_Oerlemans(GRID)
-
+    if albedo_method == 'Bougamont05':
+        alphaMod, albedo_snow = method_Bougamont(GRID,surface_temperature,albedo_snow)
     else:
         raise ValueError("Albedo method = \"{:s}\" is not allowed, must be one of {:s}".format(albedo_method, ", ".join(albedo_allowed)))
 
-    return alphaMod
+    return alphaMod, albedo_snow
 
 
 def method_Oerlemans(GRID):
@@ -47,6 +48,56 @@ def method_Oerlemans(GRID):
         alphaMod = albedo_ice
 
     return alphaMod
+
+def method_Bougamont(GRID,surface_temperature,albedo_snow):
+
+    # Get hours since the last snowfall
+    # First get fresh snow properties (height and timestamp)
+    _ , fresh_snow_timestamp, _  = GRID.get_fresh_snow_props()
+
+    # Get time difference between last snowfall and now:
+    hours_since_snowfall = (fresh_snow_timestamp) / 3600.0
+
+    # Convert integration time from seconds to days:
+    dt_days = dt / 86400.0
+
+    # Note: accounting for disapearance of uppermost fresh snow layer difficult due to non-constant decay rate. Unsure how to implement.
+
+    # Get current snowheight from layer height:
+    h = GRID.get_total_snowheight()
+
+    # Check if snow or ice:
+    if (GRID.get_node_density(0) <= snow_ice_threshold):
+
+        if surface_temperature >= zero_temperature:
+            # Snow albedo decay timescale (t*) on a melting snow surface:
+            t_star = t_star_wet
+        else:
+            # Snow albedo decay timescale (t*) on a dry snow surface:
+            if surface_temperature < t_star_cutoff:
+                t_star = t_star_dry + (zero_temperature - t_star_cutoff) * t_star_K
+            else:
+                t_star = t_star_dry + (zero_temperature - surface_temperature) * t_star_K
+
+        # Effect of snow albedo decay due to the temporal metamorphosis of snow (Bougamont et al. 2005 - based off Oerlemans & Knap 1998):
+        # Exponential function discretised in order to account for variable surface temperature-dependant decay timescales.
+        albedo_snow = albedo_snow - (albedo_snow - albedo_firn) / t_star * dt_days 
+
+        # Reset if snowfall in current timestep
+        if hours_since_snowfall == 0:    
+            albedo_snow = albedo_fresh_snow
+
+        # Effect of surface albedo decay due to the snow depth (Oerlemans & Knap 1998):
+        alphaMod = albedo_snow + (albedo_ice - albedo_snow) *  np.exp((-1.0 * h) / (albedo_mod_snow_depth / 100.0))
+        
+    else:
+        # If no snow cover than set albedo to ice albedo
+        alphaMod = albedo_ice
+
+    # Ensure output value is of the float data type.
+    alphaMod = float(alphaMod)
+
+    return alphaMod, albedo_snow
 
 ### idea; albedo decay like (Brock et al. 2000)? or?
 ### Schmidt et al 2017 >doi:10.5194/tc-2017-67, 2017 use the same albedo parameterisation from Oerlemans and Knap 1998 with a slight updated implementation of considering the surface temperature?


### PR DESCRIPTION
Incorporation of a surface temperature-dependant albedo decay method based off Bougamont et al., 2005 (doi: 10.1029/2005JF000348) - an extension of the currently available Oerlemans and Knapp 1998 approach currently within COSIPY. This scheme has already been succesfully implemented into the Energy Balance Firn Model (EBFM) of W. van Pelt, 2014 (doi:10.5194/tc-6-641-2012) and this is essentially a conversion of the MATLAB code into COSIPY's Python source code.

Notes:
- The method is de-coupled from the surface energy balance solver; the albedo decay for the current timestep is parameterised based on the surface temperature calculated from the preceeding timestep. Therefore, there must be initial values for the first timestep. Surface temperature is currently arbitrarily set to 270K.
- The 4 additional parameters within 'constants.py' could perhaps be renamed to tie in with the existing naming convention for the Oerlemans98 parameters. It might also be helpful to distinguish which are required for which.
- Ideally it would be best if this new code could be tested further before its addition to the base/master branch. I have only conducted limited testing for Colle Gnifetti, Swiss Alps.

(Code modifications contained with the 'Bougamont05-Albedo' branch)