### PR TITLE
Addition of Essery & Etchevers (2004) Turbulent Fluxes Method

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -10,7 +10,8 @@ max_layers = 200                                # Max. number of layers, just fo
 z = 2.0                                         # Measurement height [m]
 
 ' PARAMETERIZATIONS '
-stability_correction = 'Ri'                     # possibilities: 'Ri','MO'
+turbulent_fluxes_method = 'Foken08'             # possibilities: 'Foken08', 'Essery&Etchevers04'
+stability_correction = 'Ri'                     # possibilities: 'Ri','MO' (Foken08 only)
 albedo_method = 'Oerlemans98'                   # possibilities: 'Oerlemans98','Bougamont05'
 densification_method = 'Boone'                  # possibilities: 'Boone','empirical','constant' TODO: solve error Vionnet
 penetrating_method = 'Bintanja95'               # possibilities: 'Bintanja95'


### PR DESCRIPTION
Addition of an alternative means to calculate the turbulent flux exchange in the surface energy balance.

Essery & Etchevers, 2004 (https://doi.org/10.1029/2004JD005036.)

(Code modifications contained within the 'Essery & Etchevers Turbulent Fluxes' branch)