### PR TITLE
Bug Fix? - Energy & Mass Conservation in Refreezing Module [Option A]

### DIFF
--- a/cosipy/modules/refreezing.py
+++ b/cosipy/modules/refreezing.py
@@ -19,7 +19,11 @@ def refreezing(GRID):
     # Loop over all internal grid points for percolation
     for idxNode in range(0, GRID.number_nodes-1, 1):
 
-        if ((GRID.get_node_temperature(idxNode)-zero_temperature<1e-3) & (GRID.get_node_liquid_water_content(idxNode)>theta_r)):
+        if (
+            (GRID.get_node_temperature(idxNode) - zero_temperature < 1e-3)
+            & (GRID.get_node_liquid_water_content(idxNode) > theta_r)
+            & (GRID.get_node_ice_fraction(idxNode))
+        ):
 
             # Temperature difference between layer and freezing temperature, cold content in temperature
             dT = GRID.get_node_temperature(idxNode) - zero_temperature

--- a/cosipy/modules/refreezing.py
+++ b/cosipy/modules/refreezing.py
@@ -35,7 +35,7 @@ def refreezing(GRID):
                 dtheta_w = theta_r - GRID.get_node_liquid_water_content(idxNode)
 
             dtheta_i = (water_density/ice_density) * -dtheta_w
-            dT       = dtheta_i / A
+            dT       = dtheta_i / (A * GRID.get_node_ice_fraction(idxNode))
             GRID.set_node_temperature(idxNode, GRID.get_node_temperature(idxNode)+dT)
 
             if ((GRID.get_node_ice_fraction(idxNode)+dtheta_i+theta_r) >= 1.0):

--- a/cosipy/modules/refreezing.py
+++ b/cosipy/modules/refreezing.py
@@ -22,7 +22,7 @@ def refreezing(GRID):
         if (
             (GRID.get_node_temperature(idxNode) - zero_temperature < 1e-3)
             & (GRID.get_node_liquid_water_content(idxNode) > theta_r)
-            & (GRID.get_node_ice_fraction(idxNode))
+            & (GRID.get_node_ice_fraction(idxNode) > 0.0)
         ):
 
             # Temperature difference between layer and freezing temperature, cold content in temperature


### PR DESCRIPTION
I believe line 38 of the "refreezing.py" module has a rather serious error where mass-energy conservation is not correctly adheered to. The underlying equation is:

   `Q_internal_energy change of layer = Q_latent_heat_release from refreezing water`

   `=>   m_ice * c_ice * ΔT = Δm_water * L_fusion`

This can be expressed in COSIPY's volumetric form as follows:

    `=>   (θ_ice * ρ_ice) * c_ice * ΔT = (Δθ_water * ρ_water) * L_fusion`
By using the "conversion factor" (A) equal to (c_ice * ρ_ice) / (ρ_water * L_fusion) , and rearranging, this can be simplified to:

    `=>   ΔT = Δθ_water / (A * θ_ice)`
    (or alternatively ` ' ΔT = Δθ_ice / (A * θ_ice) '`   if the term is converted as in line 37 of the code.)

Line 38 in the current cosipy code is missing the `'θ_ice'` term completely.

The current setup of the code therefore heavily underestimates latent heat release of refreezing meltwater - critical in the modelling of cold firn in the accumulation zone of a glacier.

(Code modifications contained within the 'Bug_Fix_Refreezing' branch)

**Option A:** Minor changes to the original file - does not allow refreezing of water in cells with no ice content.