### PR TITLE
fix: fix wrfxcspy default pathing

### DIFF
--- a/cosipy/config.py
+++ b/cosipy/config.py
@@ -19,12 +19,12 @@ def set_parser() -> argparse.ArgumentParser:
         "Coupled snowpack and ice surface energy and mass balance model in Python."
     )
     parser = argparse.ArgumentParser(prog="COSIPY", description=tagline)
-    current_directory = os.getcwd()
+    directory_path = os.environ.get("COSIPY_DIR", ".")
     # Optional arguments
     parser.add_argument(
         "-c",
         "--config",
-        default=f"{current_directory}/config.toml",
+        default=f"{directory_path}/config.toml",
         dest="config_path",
         type=str,
         metavar="<path>",
@@ -35,7 +35,7 @@ def set_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-x",
         "--constants",
-        default=f"{current_directory}/constants.toml",
+        default=f"{directory_path}/constants.toml",
         dest="constants_path",
         type=str,
         metavar="<path>",
@@ -46,7 +46,7 @@ def set_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-s",
         "--slurm",
-        default=f"{current_directory}/slurm_config.toml",
+        default=f"{directory_path}/slurm_config.toml",
         dest="slurm_path",
         type=str,
         metavar="<path>",

--- a/cosipy/config.py
+++ b/cosipy/config.py
@@ -4,6 +4,7 @@ Hook configuration files for COSIPY.
 
 import argparse
 import sys
+import os
 from importlib.metadata import entry_points
 
 if sys.version_info >= (3, 11):
@@ -18,12 +19,12 @@ def set_parser() -> argparse.ArgumentParser:
         "Coupled snowpack and ice surface energy and mass balance model in Python."
     )
     parser = argparse.ArgumentParser(prog="COSIPY", description=tagline)
-
+    current_directory = os.getcwd()
     # Optional arguments
     parser.add_argument(
         "-c",
         "--config",
-        default="./config.toml",
+        default=f"{current_directory}/config.toml",
         dest="config_path",
         type=str,
         metavar="<path>",
@@ -34,7 +35,7 @@ def set_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-x",
         "--constants",
-        default="./constants.toml",
+        default=f"{current_directory}/constants.toml",
         dest="constants_path",
         type=str,
         metavar="<path>",
@@ -45,7 +46,7 @@ def set_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-s",
         "--slurm",
-        default="./slurm_config.toml",
+        default=f"{current_directory}/slurm_config.toml",
         dest="slurm_path",
         type=str,
         metavar="<path>",

--- a/cosipy/config.py
+++ b/cosipy/config.py
@@ -3,8 +3,9 @@ Hook configuration files for COSIPY.
 """
 
 import argparse
-import sys
 import os
+import pathlib
+import sys
 from importlib.metadata import entry_points
 
 if sys.version_info >= (3, 11):
@@ -13,20 +14,44 @@ else:
     import tomli as tomllib  # backwards compatibility
 
 
+def get_cosipy_path_from_env(name: str = "COSIPY_DIR") -> pathlib.Path:
+    """Get path to COSIPY directory.
+
+    When using WRFxCSPY, the coupler will default to searching for
+    config files in the current working directory, which may contain the
+    COSIPY source code. This function instead loads an environment
+    variable.
+
+    Args:
+        name: Name of environment variable pointing to the COSIPY
+            directory.
+
+    Returns:
+        Path to the COSIPY directory.
+
+    Raises:
+        NotADirectoryError: Invalid path.
+    """
+    cosipy_path = pathlib.Path(os.environ.get(name, os.getcwd()))
+    if not cosipy_path.is_dir():
+        raise NotADirectoryError(f"Invalid path at: {cosipy_path}")
+
+    return cosipy_path
+
+
 def set_parser() -> argparse.ArgumentParser:
     """Set argument parser for COSIPY."""
-    tagline = (
-        "Coupled snowpack and ice surface energy and mass balance model in Python."
-    )
+    tagline = "Coupled snowpack and ice surface energy and mass balance model in Python."
     parser = argparse.ArgumentParser(prog="COSIPY", description=tagline)
-    directory_path = os.environ.get("COSIPY_DIR", ".")
+    cosipy_path = get_cosipy_path_from_env()
+
     # Optional arguments
     parser.add_argument(
         "-c",
         "--config",
-        default=f"{directory_path}/config.toml",
+        default=cosipy_path / "config.toml",
         dest="config_path",
-        type=str,
+        type=pathlib.Path,
         metavar="<path>",
         required=False,
         help="relative path to configuration file",
@@ -35,9 +60,9 @@ def set_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-x",
         "--constants",
-        default=f"{directory_path}/constants.toml",
+        default=cosipy_path / "constants.toml",
         dest="constants_path",
-        type=str,
+        type=pathlib.Path,
         metavar="<path>",
         required=False,
         help="relative path to constants file",
@@ -46,9 +71,9 @@ def set_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-s",
         "--slurm",
-        default=f"{directory_path}/slurm_config.toml",
+        default=cosipy_path / "slurm_config.toml",
         dest="slurm_path",
-        type=str,
+        type=pathlib.Path,
         metavar="<path>",
         required=False,
         help="relative path to Slurm configuration file",

--- a/cosipy/tests/conftest.py
+++ b/cosipy/tests/conftest.py
@@ -38,6 +38,15 @@ def conftest_mock_check_file_exists():
 
 
 @pytest.fixture(scope="function", autouse=False)
+def conftest_mock_check_directory_exists():
+    """Override checks when mocking directories."""
+
+    patcher = patch("pathlib.Path.is_dir")
+    mock_exists = patcher.start()
+    mock_exists.return_value = True
+
+
+@pytest.fixture(scope="function", autouse=False)
 def conftest_disable_jit():
     # numba.config.DISABLE_JIT = True
     raise NotImplementedError(

--- a/cosipy/utilities/config_utils.py
+++ b/cosipy/utilities/config_utils.py
@@ -3,6 +3,7 @@ Hook configuration files for COSIPY utilities.
 """
 
 import argparse
+import pathlib
 import sys
 from collections import namedtuple
 
@@ -73,9 +74,9 @@ class UtilitiesConfig(TomlLoader):
         parser.add_argument(
             "-u",
             "--utilities",
-            default="./utilities_config.toml",
+            default=pathlib.Path("./utilities_config.toml"),
             dest="utilities_path",
-            type=str,
+            type=pathlib.Path,
             metavar="<path>",
             required=False,
             help="relative path to utilities' configuration file",


### PR DESCRIPTION
Fixes configuration hook not finding default configuration file paths.

Loads an environment variable COSIPY_DIR (set when patching WRFxCSPY) if present.

Fixes #86 
Refs: cryotools/wrf_x_cspy#1